### PR TITLE
Handle linux desktop arm64 arch with Qt 6.7.0 via new linux_arm64 host.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 20
-    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        fetch-tags: true
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test-install-qt.yml
+++ b/.github/workflows/test-install-qt.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 20
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          fetch-tags: true
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/aqt/archives.py
+++ b/aqt/archives.py
@@ -367,7 +367,7 @@ class QtArchives:
     def _append_depends_tool(self, arch, tool_name):
         os_target_folder = posixpath.join(
             "online/qtsdkrepository",
-            self.os_name + ("_x86" if self.os_name == "windows" else "_x64"),
+            self.os_name + ("_x86" if self.os_name == "windows" else ("" if self.os_name == "linux_arm64" else "_x64")),
             self.target,
             tool_name,
         )
@@ -379,7 +379,7 @@ class QtArchives:
     def _get_archives_base(self, name, target_packages):
         os_target_folder = posixpath.join(
             "online/qtsdkrepository",
-            self.os_name + ("_x86" if self.os_name == "windows" else "_x64"),
+            self.os_name + ("_x86" if self.os_name == "windows" else ("" if self.os_name == "linux_arm64" else "_x64")),
             self.target,
             # tools_ifw/
             name,

--- a/aqt/combinations.json
+++ b/aqt/combinations.json
@@ -435,6 +435,11 @@
         "target": "desktop"
       },
       {
+        "arch": "linux_gcc_arm64",
+        "os_name": "linux_arm64",
+        "target": "desktop"
+      },
+      {
         "arch": "wasm_32",
         "os_name": "linux",
         "target": "desktop"

--- a/aqt/installer.py
+++ b/aqt/installer.py
@@ -261,7 +261,15 @@ class Cli:
         if arch is not None and arch != "":
             return arch
         if os_name == "linux" and target == "desktop":
-            return "gcc_64"
+            try:
+                if Version(qt_version_or_spec) >= Version("6.7.0"):
+                    return "linux_gcc_64"
+                else:
+                    return "gcc_64"
+            except ValueError:
+                return "gcc_64"
+        elif os_name == "linux_arm64" and target == "desktop":
+            return "linux_gcc_arm64"
         elif os_name == "mac" and target == "desktop":
             return "clang_64"
         elif os_name == "mac" and target == "ios":
@@ -730,7 +738,7 @@ class Cli:
 
     def _set_install_tool_parser(self, install_tool_parser, *, is_legacy: bool):
         install_tool_parser.set_defaults(func=self.run_install_tool, is_legacy=is_legacy)
-        install_tool_parser.add_argument("host", choices=["linux", "mac", "windows"], help="host os name")
+        install_tool_parser.add_argument("host", choices=["linux", "linux_arm64", "mac", "windows"], help="host os name")
         if not is_legacy:
             install_tool_parser.add_argument(
                 "target",
@@ -787,7 +795,7 @@ class Cli:
 
         def make_parser_list_sde(cmd: str, desc: str, cmd_type: str):
             parser = subparsers.add_parser(cmd, description=desc)
-            parser.add_argument("host", choices=["linux", "mac", "windows"], help="host os name")
+            parser.add_argument("host", choices=["linux", "linux_arm64", "mac", "windows"], help="host os name")
             parser.add_argument(
                 "qt_version_spec",
                 metavar="(VERSION | SPECIFICATION)",
@@ -835,7 +843,7 @@ class Cli:
             "$ aqt list-qt mac desktop --archives 5.9.0 clang_64              # list archives in base Qt installation\n"
             "$ aqt list-qt mac desktop --archives 5.14.0 clang_64 debug_info  # list archives in debug_info module\n",
         )
-        list_parser.add_argument("host", choices=["linux", "mac", "windows"], help="host os name")
+        list_parser.add_argument("host", choices=["linux", "linux_arm64", "mac", "windows"], help="host os name")
         list_parser.add_argument(
             "target",
             nargs="?",
@@ -919,7 +927,7 @@ class Cli:
             "$ aqt list-tool mac desktop tools_ifw --long  # print tool variant names with metadata for QtIFW\n"
             "$ aqt list-tool mac desktop ifw --long        # print tool variant names with metadata for QtIFW\n",
         )
-        list_parser.add_argument("host", choices=["linux", "mac", "windows"], help="host os name")
+        list_parser.add_argument("host", choices=["linux", "linux_arm64", "mac", "windows"], help="host os name")
         list_parser.add_argument(
             "target",
             nargs="?",
@@ -1006,7 +1014,7 @@ class Cli:
         """
         if is_legacy:
             subparser.add_argument("qt_version", help='Qt version in the format of "5.X.Y"')
-        subparser.add_argument("host", choices=["linux", "mac", "windows"], help="host os name")
+        subparser.add_argument("host", choices=["linux", "linux_arm64", "mac", "windows"], help="host os name")
         if is_target_deprecated:
             subparser.add_argument(
                 "target",

--- a/aqt/metadata.py
+++ b/aqt/metadata.py
@@ -199,11 +199,12 @@ def get_semantic_version(qt_ver: str, is_preview: bool) -> Optional[Version]:
 
 class ArchiveId:
     CATEGORIES = ("tools", "qt")
-    HOSTS = ("windows", "mac", "linux")
+    HOSTS = ("windows", "mac", "linux", "linux_arm64")
     TARGETS_FOR_HOST = {
         "windows": ["android", "desktop", "winrt"],
         "mac": ["android", "desktop", "ios"],
         "linux": ["android", "desktop"],
+        "linux_arm64": ["desktop"],
     }
     EXTENSIONS_REQUIRED_ANDROID_QT6 = {"x86_64", "x86", "armv7", "arm64_v8a"}
     ALL_EXTENSIONS = {"", "wasm", "src_doc_examples", *EXTENSIONS_REQUIRED_ANDROID_QT6}
@@ -231,7 +232,7 @@ class ArchiveId:
     def to_url(self) -> str:
         return "online/qtsdkrepository/{os}{arch}/{target}/".format(
             os=self.host,
-            arch="_x86" if self.host == "windows" else "_x64",
+            arch=("_x86" if self.host == "windows" else ("" if self.host == "linux_arm64" else "_x64")),
             target=self.target,
         )
 
@@ -384,12 +385,16 @@ class QtRepoProperty:
                 return arch[6:]
         elif host == "mac" and arch == "clang_64":
             return QtRepoProperty.default_mac_desktop_arch_dir(version)
+        elif host == "linux" and arch in ("gcc_64", "linux_gcc_64"):
+            return "gcc_64"
+        elif host == "linux" and arch == "linux_gcc_arm64":
+            return "gcc_arm64"
         else:
             return arch
 
     @staticmethod
-    def default_linux_desktop_arch_dir() -> str:
-        return "gcc_64"
+    def default_linux_desktop_arch_dir() -> tuple[str, str]:
+        return ("gcc_64", "gcc_arm64")
 
     @staticmethod
     def default_win_msvc_desktop_arch_dir(_version: Version) -> str:
@@ -476,8 +481,11 @@ class QtRepoProperty:
             arch_path = installed_qt_version_dir / QtRepoProperty.default_mac_desktop_arch_dir(version)
             return arch_path if (arch_path / "bin/qmake").is_file() else None
         elif host == "linux":
-            arch_path = installed_qt_version_dir / QtRepoProperty.default_linux_desktop_arch_dir()
-            return arch_path if (arch_path / "bin/qmake").is_file() else None
+            for arch_dir in QtRepoProperty.default_linux_desktop_arch_dir():
+                arch_path = installed_qt_version_dir / arch_dir
+                if (arch_path / "bin/qmake").is_file():
+                    return arch_path
+            return None
         elif host == "windows" and is_msvc:
             arch_path = installed_qt_version_dir / QtRepoProperty.default_win_msvc_desktop_arch_dir(version)
             return arch_path if (arch_path / "bin/qmake.exe").is_file() else None


### PR DESCRIPTION
Top level directories are `qtsdkrepository/linux_x64` or `qtsdkrepository/linux_arm64` qtsdkrepository files are suffixed with `.linux_gcc_64` or `.linux_gcc_arm64` Installation directory is `gcc_64` or `gcc_arm64`